### PR TITLE
hacky fix to return a bare evolution object if the histogram is not keyed

### DIFF
--- a/v2/doc.md
+++ b/v2/doc.md
@@ -53,7 +53,7 @@ Getting the dates for which there are submissions for GC_MS on nightly 42 on Win
 ```javascript
 Telemetry.init(function() {
     Telemetry.getEvolution("nightly", "42", "GC_MS", {os: "Windows_NT"}, true, function(evolutionMap) {
-        console.log("Available dates:\n" + evolutionMap[""].dates().join("\n"));
+        console.log("Available dates:\n" + evolutionMap.dates().join("\n"));
     });
 });
 ```
@@ -63,7 +63,7 @@ Getting the overall median value of GC_MS on nightly 42 on Windows from July 19,
 ```javascript
 Telemetry.init(function() {
     Telemetry.getEvolution("nightly", "42", "GC_MS", {os: "Windows_NT"}, true, function(evolutionMap) {
-        var evolution = evolutionMap[""].dateRange(new Date("2015-07-19"), new Date("2015-08-01"));
+        var evolution = evolutionMap.dateRange(new Date("2015-07-19"), new Date("2015-08-01"));
         var histogram = evolution.histogram();
         console.log("Median GC_MS: " + histogram.percentile(50));
     });

--- a/v2/telemetry.js
+++ b/v2/telemetry.js
@@ -482,6 +482,10 @@
             entriesMap[label], histograms.kind, histograms.description,
             metric);
         };
+        // Detect un-keyed histograms and return the unwrapped evolution
+        if (Object.keys(entriesMap).length === 1 && entriesMap[0] === void 0) {
+            evolutionMap = evolutionMap[""];
+        }
         callback(evolutionMap);
       }
     });


### PR DESCRIPTION
Most data in telemetry currently is unkeyed, and it feels awkward to have to refer to the evolutions returned via getEvolution with this `evolutionMap[""].map(...)` - so I added detection of this case in getEvolution and return a bare Evolution object instead

This isn't a great solution because the argument to the callback can now be one of two different things. An alternative might be to have a convention such as 'evolutionMap.evolution' for unkeyed histograms?

Aside: this problem gets carried through to the shim and breaks v1 code as well.
